### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
+    @items = Item.all.order("created_at desc")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,31 +126,29 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <%= render partial: "itemlist", collection: @items %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開 %>
+      <% if @items != nil %>
+        <%= render partial: "shared/itemlist", collection: @items %>
+      <% elsif %>
+        <%# 商品がない場合のダミー %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
+          <% end %>
+        </li>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,32 +127,7 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
+      <%= render partial: "itemlist", collection: @items %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>

--- a/app/views/shared/_itemlist.html.erb
+++ b/app/views/shared/_itemlist.html.erb
@@ -1,8 +1,8 @@
 <li class='list'>
   <%= link_to "#" do %>
   <div class='item-img-content'>
-    <%= image_tag "item-sample.png", class: "item-img" %>
-    <%# 商品が売れていればsold outを表示しましょう %>
+    <%= image_tag itemlist.image, class: "item-img" if itemlist.image.attached? %>
+    <%# 商品が売れていればsold outを表示しましょう ※商品購入機能の実装時に対応する %>
     <div class='sold-out'>
       <span>Sold Out!!</span>
     </div>
@@ -10,10 +10,10 @@
   </div>
   <div class='item-info'>
     <h3 class='item-name'>
-      <%= "商品名" %>
+      <%= itemlist.item_name %>
     </h3>
     <div class='item-price'>
-      <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+      <span><%= itemlist.sell_price %>円<br><%= itemlist.item_shipping_fee_status.name %></span>
       <div class='star-btn'>
         <%= image_tag "star.png", class:"star-icon" %>
         <span class='star-count'>0</span>

--- a/app/views/shared/_itemlist.html.erb
+++ b/app/views/shared/_itemlist.html.erb
@@ -1,0 +1,24 @@
+<li class='list'>
+  <%= link_to "#" do %>
+  <div class='item-img-content'>
+    <%= image_tag "item-sample.png", class: "item-img" %>
+    <%# 商品が売れていればsold outを表示しましょう %>
+    <div class='sold-out'>
+      <span>Sold Out!!</span>
+    </div>
+    <%# //商品が売れていればsold outを表示しましょう %>
+  </div>
+  <div class='item-info'>
+    <h3 class='item-name'>
+      <%= "商品名" %>
+    </h3>
+    <div class='item-price'>
+      <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+      <div class='star-btn'>
+        <%= image_tag "star.png", class:"star-icon" %>
+        <span class='star-count'>0</span>
+      </div>
+    </div>
+  </div>
+  <% end %>
+</li>


### PR DESCRIPTION
レビューをお願いいたします。
※商品購入機能実装前のため、
「売却済みの商品は、画像上に『sold out』の文字が表示されるようになっていること」という機能は
実装しておりません。
（ダウンロードファイルのまま）

# 機能確認の動画
[ログアウト状態](https://gyazo.com/9e1d4b446ff709ac1d81434507840cc6)

- 出品した商品の一覧表示ができていること
- 「画像/価格/商品名」の3つの情報について表示されていること
- 一覧表示と出品日時が新しい順（created_at desc）で表示されていること
※ログアウト状態動画の下部にテーブル登録内容も映しております

[ログイン状態](https://gyazo.com/cee8b0582e541d92925fd9771d1802e2)